### PR TITLE
Removed warnings on deprecated methods by using pragma diagnostic.

### DIFF
--- a/FGallery/Classes/FGalleryViewController.m
+++ b/FGallery/Classes/FGalleryViewController.m
@@ -527,7 +527,9 @@
 	if ([application respondsToSelector: @selector(setStatusBarHidden:withAnimation:)]) {
 		[[UIApplication sharedApplication] setStatusBarHidden: YES withAnimation: UIStatusBarAnimationFade]; // 3.2+
 	} else {
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 		[[UIApplication sharedApplication] setStatusBarHidden: YES animated:YES]; // 2.0 - 3.2
+#pragma GCC diagnostic warning "-Wdeprecated-declarations"
 	}
 	
 	[self.navigationController setNavigationBarHidden:YES animated:YES];
@@ -552,7 +554,9 @@
 	if ([application respondsToSelector: @selector(setStatusBarHidden:withAnimation:)]) {
 		[[UIApplication sharedApplication] setStatusBarHidden:NO withAnimation:UIStatusBarAnimationFade]; // 3.2+
 	} else {
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 		[[UIApplication sharedApplication] setStatusBarHidden:NO animated:NO]; // 2.0 - 3.2
+#pragma GCC diagnostic warning "-Wdeprecated-declarations"
 	}
     
 	[self.navigationController setNavigationBarHidden:NO animated:YES];


### PR DESCRIPTION
Hello,

just a little cosmetic on the code - in FGalleryViewController.m the code for 2.0-3.2 issues warnings when turned on in XCode. Simply got rid of this by using the following pragmas:
# pragma GCC diagnostic ignored "-Wdeprecated-declarations"
# pragma GCC diagnostic warning "-Wdeprecated-declarations"

Would be nice if I could contribute a bit with this to your great library - thanx,

Konrad
