### PR TITLE
Modified to preserve UINavigationController's defined behavior; otherwis...

### DIFF
--- a/FGallery/Classes/FGalleryViewController.m
+++ b/FGallery/Classes/FGalleryViewController.m
@@ -1197,6 +1197,21 @@
 	{
         return YES;
 	}
+
+	// To preserve the UINavigationController's defined behavior,
+	// walk its stack.  If all of the view controllers in the stack
+	// agree they can rotate to the given orientation, then allow it.
+	BOOL supported = YES;
+	for(UIViewController *sub in self.viewControllers)
+	{
+		if(![sub shouldAutorotateToInterfaceOrientation:interfaceOrientation])
+		{
+			supported = NO;
+			break;
+		}
+	}	
+	if(supported)
+		return YES;
 	
 	// we need to support at least one type of auto-rotation we'll get warnings.
 	// so, we'll just support the basic portrait.


### PR DESCRIPTION
The existing code only allows rotation on the FGalleryViewController - all other view controllers in the navigation stack will only rotate into portrait (though they can appear in landscape if a FGalleryViewController is popped from the stack while in landscape).  This fix will walk the navigation stack to see if the stacked view controllers all support the specified orientation.  If so, then the navigation controller will allow it; otherwise, it defaults to the current code and only allows portrait.
