### PR TITLE
baritems as property + Memory Leak Fix

### DIFF
--- a/FGallery/Classes/FGalleryViewController.h
+++ b/FGallery/Classes/FGalleryViewController.h
@@ -74,6 +74,7 @@ typedef enum
 @property (nonatomic,readonly) UIToolbar *toolBar;
 @property (nonatomic,readonly) UIView* thumbsView;
 @property (nonatomic,retain) NSString *galleryID;
+@property (nonatomic,retain) NSMutableArray *barItems;
 @property (nonatomic) BOOL useThumbnailView;
 @property (nonatomic) BOOL beginsInThumbnailView;
 @property (nonatomic) BOOL hideTitle;

--- a/FGallery/Classes/FGalleryViewController.m
+++ b/FGallery/Classes/FGalleryViewController.m
@@ -488,6 +488,8 @@
             [self.navigationItem setRightBarButtonItem:nil animated:NO];
         }
     }
+	
+	[newBackButton release], newBackButton = nil;
 }
 
 

--- a/FGallery/Classes/FGalleryViewController.m
+++ b/FGallery/Classes/FGalleryViewController.m
@@ -75,6 +75,7 @@
 @synthesize startingIndex = _startingIndex;
 @synthesize beginsInThumbnailView = _beginsInThumbnailView;
 @synthesize hideTitle = _hideTitle;
+@synthesize barItems = _barItems;
 
 #pragma mark - Public Methods
 

--- a/FGallery/Classes/FGalleryViewController.m
+++ b/FGallery/Classes/FGalleryViewController.m
@@ -17,6 +17,7 @@
 @interface FGalleryViewController (Private)
 
 // general
+- (void)loadDefaultToolBar;
 - (void)buildViews;
 - (void)destroyViews;
 - (void)layoutViews;
@@ -113,6 +114,9 @@
          _scroller.layer.borderColor = [[UIColor redColor] CGColor];
          _scroller.layer.borderWidth = 2.0;
          */
+		
+		[self loadDefaultToolBar];
+
 	}
 	return self;
 }
@@ -139,6 +143,8 @@
 		_photoViews							= [[NSMutableArray alloc] init];
 		_photoThumbnailViews				= [[NSMutableArray alloc] init];
 		_barItems							= [[NSMutableArray alloc] init];
+		
+		[self loadDefaultToolBar];
 	}
 	
 	return self;
@@ -222,19 +228,7 @@
 	
 	[_toolbar addSubview:_captionContainer];
 	[_captionContainer addSubview:_caption];
-	
-	// create buttons for toolbar
-	UIImage *leftIcon = [UIImage imageNamed:@"photo-gallery-left.png"];
-	UIImage *rightIcon = [UIImage imageNamed:@"photo-gallery-right.png"];
-	_nextButton = [[UIBarButtonItem alloc] initWithImage:rightIcon style:UIBarButtonItemStylePlain target:self action:@selector(next)];
-	_prevButton = [[UIBarButtonItem alloc] initWithImage:leftIcon style:UIBarButtonItemStylePlain target:self action:@selector(previous)];
-	
-	// add prev next to front of the array
-	[_barItems insertObject:_nextButton atIndex:0];
-	[_barItems insertObject:_prevButton atIndex:0];
-	
-	_prevNextButtonSize = leftIcon.size.width;
-	
+		
 	// set buttons on the toolbar.
 	[_toolbar setItems:_barItems animated:NO];
     
@@ -494,6 +488,19 @@
 
 
 #pragma mark - Private Methods
+
+- (void)loadDefaultToolBar {
+	UIImage *leftIcon = [UIImage imageNamed:@"photo-gallery-left.png"];
+	UIImage *rightIcon = [UIImage imageNamed:@"photo-gallery-right.png"];
+	_nextButton = [[UIBarButtonItem alloc] initWithImage:rightIcon style:UIBarButtonItemStylePlain target:self action:@selector(next)];
+	_prevButton = [[UIBarButtonItem alloc] initWithImage:leftIcon style:UIBarButtonItemStylePlain target:self action:@selector(previous)];
+	
+	// add prev next to front of the array
+	[_barItems addObject:_prevButton];
+	[_barItems addObject:_nextButton];
+	
+	_prevNextButtonSize = leftIcon.size.width;
+}
 
 - (void)observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object change:(NSDictionary *)change context:(void *)context
 {


### PR DESCRIPTION
_barItems is now a property, so it can be used after the initWithCoder Method has been called.
Fixes a Memory Leak which occurs at -setUseThumbnailView: