### PR TITLE
Support Full Path

### DIFF
--- a/FGallery/Classes/FGalleryPhoto.m
+++ b/FGallery/Classes/FGalleryPhoto.m
@@ -123,7 +123,16 @@
 {
 	NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
 	
-	NSString *path = [NSString stringWithFormat:@"%@/%@", [[NSBundle mainBundle] bundlePath], _fullsizeUrl];
+	NSString *path;
+        
+        if([[NSFileManager defaultManager] fileExistsAtPath:_fullsizeUrl])
+        {
+            path = _fullsizeUrl;
+        }
+        else {
+            path = [NSString stringWithFormat:@"%@/%@", [[NSBundle mainBundle] bundlePath], _fullsizeUrl];
+        }
+			
 	_fullsize = [[UIImage imageWithContentsOfFile:path] retain];
 	
 	_hasFullsizeLoaded = YES;
@@ -139,7 +148,16 @@
 {
 	NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
 	
-	NSString *path = [NSString stringWithFormat:@"%@/%@", [[NSBundle mainBundle] bundlePath], _thumbUrl];
+	NSString *path;
+        
+        if([[NSFileManager defaultManager] fileExistsAtPath:_thumbUrl])
+        {
+            path = _thumbUrl;
+        }
+        else {
+            path = [NSString stringWithFormat:@"%@/%@", [[NSBundle mainBundle] bundlePath], _thumbUrl];
+        }
+		
 	_thumbnail = [[UIImage imageWithContentsOfFile:path] retain];
 	
 	_hasThumbLoaded = YES;


### PR DESCRIPTION
If we are using [[NSBundle mainBundle] bundlePath]  , it couldn't support NSLibrary or NSDocumentPath to view the image.

Added some code in FGalleryPhoto.m to check file exist or not.
